### PR TITLE
Add keywords for messages

### DIFF
--- a/Source/Marvirc/Bin/Join.php
+++ b/Source/Marvirc/Bin/Join.php
@@ -208,6 +208,21 @@ class Join extends Console\Dispatcher\Kit {
             return;
         });
 
+        // Message.
+        $client->on('message', function ( $bucket ) use ( $self ) {
+
+            $data   = $bucket->getData();
+            $answer = null;
+
+            if(0 !== preg_match('/!(?=\b)/', $data['message']))
+                $answer = $self->getAnswer('Mention', $data, null);
+
+            if(null !== $answer)
+                $bucket->getSource()->say($answer);
+
+            return;
+        });
+
         // Here we go.
         $group->run();
 


### PR DESCRIPTION
During talk Marvirc will verify if some keywords is mentionned and react
on it

Two keywords have been added:
- !hack => to access to hackbook
- !source => to display url to code source.

It's the same usage than the previous behavior but add a possibility to
not interact directly with Marvirc
